### PR TITLE
[Assessment] - adding more interesting seed for assessment

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,6 +1,6 @@
 require 'faker'
 
-age_range = [[10, 15], [16, 20], [21, 25], [26, 30], [31, 40], [41, 60]]
+age_range = [[10, 16], [13, 20], [18, 25], [21, 30], [28, 40], [38, 60]]
 age_range.each_with_index do |range, i|
   AgeGroup.create!(name: "group #{i}",
                   start_age: range[0],


### PR DESCRIPTION
I made the age groups overlap more, so if you pick a user (or just update their age in console), to be an age that is in two different age groups. Then find a game in the admin portal that will have two groups that user is in (gender and age), you can see that when you update play hours, it affects both groups. I feel like marketers would have age groups overlap. The way it was before when you log play its more rare that it affects more than one group. Wanted to show off the idea that both groups are affected.